### PR TITLE
Use *args to fit exception convention.

### DIFF
--- a/exceptiongroup/__init__.py
+++ b/exceptiongroup/__init__.py
@@ -25,7 +25,15 @@ class ExceptionGroup(BaseException):
 
     """
 
-    def __init__(self, message, exceptions, sources):
+    def __init__(self, *args):
+        EXPECT_ARG_LENGTH = 3
+        if len(args) < EXPECT_ARG_LENGTH:
+            raise ValueError(
+                "The length of args should be equal to {}".format(
+                    EXPECT_ARG_LENGTH
+                )
+            )
+        message, exceptions, sources = args[0], args[1], args[2]
         super().__init__(message)
         self.exceptions = list(exceptions)
         for exc in self.exceptions:
@@ -51,6 +59,12 @@ class ExceptionGroup(BaseException):
         new_group.__context__ = self.__context__
         new_group.__cause__ = self.__cause__
         return new_group
+
+    def __str__(self):
+        return ", ".join(repr(exc) for exc in self.exceptions)
+
+    def __repr__(self):
+        return "<ExceptionGroup: {}>".format(self)
 
 
 from . import _monkeypatch

--- a/exceptiongroup/__init__.py
+++ b/exceptiongroup/__init__.py
@@ -25,16 +25,8 @@ class ExceptionGroup(BaseException):
 
     """
 
-    def __init__(self, *args):
-        EXPECT_ARG_LENGTH = 3
-        if len(args) < EXPECT_ARG_LENGTH:
-            raise ValueError(
-                "The length of args should be equal to {}".format(
-                    EXPECT_ARG_LENGTH
-                )
-            )
-        message, exceptions, sources = args[0], args[1], args[2]
-        super().__init__(message)
+    def __init__(self, message, exceptions, sources):
+        super().__init__(message, exceptions, sources)
         self.exceptions = list(exceptions)
         for exc in self.exceptions:
             if not isinstance(exc, BaseException):

--- a/exceptiongroup/_tests/test_exceptiongroup.py
+++ b/exceptiongroup/_tests/test_exceptiongroup.py
@@ -12,7 +12,11 @@ def test_exception_group_init():
     assert group.exceptions == [memberA, memberB]
     assert group.message == "many error."
     assert group.sources == [str(memberA), str(memberB)]
-    assert group.args == ("many error.", [memberA, memberB], [str(memberA), str(memberB)])
+    assert group.args == (
+        "many error.",
+        [memberA, memberB],
+        [str(memberA), str(memberB)],
+    )
 
 
 def test_exception_group_when_members_are_not_exceptions():

--- a/exceptiongroup/_tests/test_exceptiongroup.py
+++ b/exceptiongroup/_tests/test_exceptiongroup.py
@@ -1,0 +1,40 @@
+import pytest
+
+from exceptiongroup import ExceptionGroup
+
+
+def test_exception_group_init():
+    memberA = ValueError("A")
+    memberB = RuntimeError("B")
+    group = ExceptionGroup(
+        "many error.", [memberA, memberB], [str(memberA), str(memberB)]
+    )
+    assert group.exceptions == [memberA, memberB]
+    assert group.message == "many error."
+    assert group.sources == [str(memberA), str(memberB)]
+
+
+def test_exception_group_init_when_length_of_args_is_less_than_3():
+    with pytest.raises(ValueError):
+        ExceptionGroup("error")
+
+
+def test_exception_group_init_when_exceptions_messages_not_equal():
+    with pytest.raises(ValueError):
+        ExceptionGroup(
+            "many error.", [ValueError("A"), RuntimeError("B")], ["A"]
+        )
+
+
+def test_exception_group_str():
+    memberA = ValueError("memberA")
+    memberB = ValueError("memberB")
+    group = ExceptionGroup(
+        "many error.", [memberA, memberB], [str(memberA), str(memberB)]
+    )
+    assert "memberA" in str(group)
+    assert "memberB" in str(group)
+
+    assert "ExceptionGroup: " in repr(group)
+    assert "memberA" in repr(group)
+    assert "memberB" in repr(group)

--- a/exceptiongroup/_tests/test_exceptiongroup.py
+++ b/exceptiongroup/_tests/test_exceptiongroup.py
@@ -14,6 +14,15 @@ def test_exception_group_init():
     assert group.sources == [str(memberA), str(memberB)]
 
 
+def test_exception_group_when_members_are_not_exceptions():
+    with pytest.raises(TypeError):
+        ExceptionGroup(
+            "error",
+            [RuntimeError("RuntimeError"), "error2"],
+            ["RuntimeError", "error2"],
+        )
+
+
 def test_exception_group_init_when_length_of_args_is_less_than_3():
     with pytest.raises(ValueError):
         ExceptionGroup("error")

--- a/exceptiongroup/_tests/test_exceptiongroup.py
+++ b/exceptiongroup/_tests/test_exceptiongroup.py
@@ -12,6 +12,7 @@ def test_exception_group_init():
     assert group.exceptions == [memberA, memberB]
     assert group.message == "many error."
     assert group.sources == [str(memberA), str(memberB)]
+    assert group.args == ("many error.", [memberA, memberB], [str(memberA), str(memberB)])
 
 
 def test_exception_group_when_members_are_not_exceptions():

--- a/exceptiongroup/_tests/test_exceptiongroup.py
+++ b/exceptiongroup/_tests/test_exceptiongroup.py
@@ -23,11 +23,6 @@ def test_exception_group_when_members_are_not_exceptions():
         )
 
 
-def test_exception_group_init_when_length_of_args_is_less_than_3():
-    with pytest.raises(ValueError):
-        ExceptionGroup("error")
-
-
 def test_exception_group_init_when_exceptions_messages_not_equal():
     with pytest.raises(ValueError):
         ExceptionGroup(


### PR DESCRIPTION
Try to resolve for issue #8 

A little consideration:
1. Should we output `warning` when user pass more than 3 arguments into `constructor`?  Here I don't show warning because I think the warning message is a little annoying.  User can know what should pass to ExceptionGroup constructor after reading the `__doc__`.
2. The method of `__str__` and `__repr__`.  I just implement it using the same approach as what `MultiError` in `trio` do.  I think it's just fine.
