### PR TITLE
very-very first version decorator-based exception catch API (Introduce HandlerChain)

### DIFF
--- a/exceptiongroup/__init__.py
+++ b/exceptiongroup/__init__.py
@@ -2,7 +2,7 @@
 
 from ._version import __version__
 
-__all__ = ["ExceptionGroup", "split", "catch"]
+__all__ = ["ExceptionGroup", "split", "catch", "HandlerChain"]
 
 
 class ExceptionGroup(BaseException):
@@ -64,4 +64,4 @@ class ExceptionGroup(BaseException):
 
 
 from . import _monkeypatch
-from ._tools import split, catch
+from ._tools import split, catch, HandlerChain

--- a/exceptiongroup/_tests/test_scripts/handler.py
+++ b/exceptiongroup/_tests/test_scripts/handler.py
@@ -1,0 +1,26 @@
+""" Test script for the HandlerChain.
+
+From here we can see the output exception after HandlerChain handled.
+"""
+from exceptiongroup import HandlerChain
+
+chain = HandlerChain()
+
+
+def raise_error_with_context():
+    try:
+        raise RuntimeError("This is a runtime error")
+    except Exception:
+        try:
+            raise ValueError("This is a value error")
+        except Exception:
+            raise ZeroDivisionError("Fake zero division error")
+
+
+with chain:
+
+    @chain.handle(ZeroDivisionError)
+    def handler(exc):
+        raise
+
+    raise_error_with_context()

--- a/exceptiongroup/_tests/test_scripts/handler.py
+++ b/exceptiongroup/_tests/test_scripts/handler.py
@@ -2,25 +2,37 @@
 
 From here we can see the output exception after HandlerChain handled.
 """
-from exceptiongroup import HandlerChain
+from exceptiongroup import HandlerChain, ExceptionGroup
 
 chain = HandlerChain()
 
 
-def raise_error_with_context():
+def raise_error():
+    raise ValueError("Another value error")
+
+
+def raise_another_error():
+    raise RuntimeError("Another runtime error")
+
+
+def raise_group():
     try:
-        raise RuntimeError("This is a runtime error")
-    except Exception:
-        try:
-            raise ValueError("This is a value error")
-        except Exception:
-            raise ZeroDivisionError("Fake zero division error")
+        raise_error()
+    except Exception as e:
+        val_err = e
+
+    try:
+        raise_another_error()
+    except Exception as e:
+        run_err = e
+
+    raise ExceptionGroup("group", [val_err, run_err], [str(val_err), str(run_err)])
 
 
 with chain:
 
-    @chain.handle(ZeroDivisionError)
+    @chain.handle(ValueError)
     def handler(exc):
-        raise
+        raise ZeroDivisionError('zero division error.')
 
-    raise_error_with_context()
+    raise_group()

--- a/exceptiongroup/_tests/test_scripts/handler.py
+++ b/exceptiongroup/_tests/test_scripts/handler.py
@@ -26,13 +26,15 @@ def raise_group():
     except Exception as e:
         run_err = e
 
-    raise ExceptionGroup("group", [val_err, run_err], [str(val_err), str(run_err)])
+    raise ExceptionGroup(
+        "group", [val_err, run_err], [str(val_err), str(run_err)]
+    )
 
 
 with chain:
 
     @chain.handle(ValueError)
     def handler(exc):
-        raise ZeroDivisionError('zero division error.')
+        raise ZeroDivisionError("zero division error.")
 
     raise_group()

--- a/exceptiongroup/_tests/test_tools.py
+++ b/exceptiongroup/_tests/test_tools.py
@@ -1,5 +1,5 @@
 import pytest
-from exceptiongroup import ExceptionGroup, split
+from exceptiongroup import ExceptionGroup, split, HandlerChain
 
 
 def raise_error(err):
@@ -113,3 +113,23 @@ def test_split_and_check_attributes_same():
     assert unmatched.__cause__ is new_group.__cause__
     assert unmatched.__context__ is new_group.__context__
     assert unmatched.__suppress_context__ is new_group.__suppress_context__
+
+
+def test_handler_chain_when_raise_bare_exception():
+    pass
+
+
+def test_handler_chain_when_raise_exception_group():
+    pass
+
+
+def test_handler_chain_when_raise_exception_group_with_all_handled():
+    pass
+
+
+def test_handler_chain_when_raise_exception_group_with_all_unhandled():
+    pass
+
+
+def test_handler_chain_when_raise_exception_group_with_partly_handled():
+    pass

--- a/exceptiongroup/_tools.py
+++ b/exceptiongroup/_tools.py
@@ -150,6 +150,9 @@ class HandlerChain:
                 # use `raise` rather than `raise e` to make our traceback
                 # more readable
                 raise
+        else:
+            # Or swallow the exception, because handler eat it.
+            return True
 
 
 class Catcher:


### PR DESCRIPTION
I have tried to implement with the way using `HandlerChain` (which is close to the last proposol inside #5 I think.)
But for now it's just handle for the simlest case: the handled exc is not an instance of ExceptionGroup.  (the `exc` can be an instance of `ExceptionGroup`, but the output traceback information is not so clearly.)
Sorry for the disturb......I'm afraid my solution is too bad to go on :(
So I submit this PR, hope it can help us to see the new picture.

=======================================
**For the actual changes:**
It's a little different to the last proposol, which is:

```python
with open_handler() as handler:
    @handler.handle(RuntimeError)
    def handler1(exc):
        ...
```

In the PR here, the usage is:

```python
handler = HandlerChain()
with handler:
    @handler.handle(RuntimeError)
    def handler1(exc):
        ...
```

After a little thought about it, I think if we use HandlerChain, we can re-use the chain when we need it, so we don't need to re-define function inside every `with` block.  And we can write code like this:
```python
# a.py
handler = HandlerChain()

@handler.handle(RuntimeError)
def handler1(exc):
    ...

@handler.handle(ValueError)
def handler2(exc):
    ...


# b.py
with handler:
    ...
```

Note that there are decisions make by the handler:
1. when code inside `with handler` raise Exception, the handler will always raise an instance of `ExceptionGroup`.
2. If the handler re-raised exception, we will not see the traceback in-side the handler, instead, we will show the actual user code.  The same thing happened with **__context__** property.

I have add the test_script named `handler.py`, we can run the script to see what's going on there :)